### PR TITLE
MAINT: Change denumerator->denominator

### DIFF
--- a/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
+++ b/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
@@ -54,7 +54,7 @@ function write_to_file(fn,s)
 function coverage=compute_coverage(obj)
 
     numerator=0;
-    denumerator=0;
+    denominator=0;
 
     for k=1:numel(obj.mfiles)
         mfile=obj.mfiles{k};
@@ -63,9 +63,9 @@ function coverage=compute_coverage(obj)
         ed=get_lines_executed(mfile);
 
         numerator=numerator+sum(ed & able);
-        denumerator=denumerator+sum(able);
+        denominator=denominator+sum(able);
     end
 
-    coverage=numerator/denumerator;
+    coverage=numerator/denominator;
 
 

--- a/MOcov/@MOcovMFileCollection/write_xml_file.m
+++ b/MOcov/@MOcovMFileCollection/write_xml_file.m
@@ -71,7 +71,7 @@ function write_to_file(fn,s)
 function coverage=compute_coverage(obj)
 % compute overall coverage across all files
     numerator=0;
-    denumerator=0;
+    denominator=0;
 
     for k=1:count_mfiles(obj)
         mfile=get_mfile(obj,k);
@@ -80,9 +80,9 @@ function coverage=compute_coverage(obj)
         executed=get_lines_executed(mfile);
 
         numerator=numerator+sum(executed & executable);
-        denumerator=denumerator+sum(executable);
+        denominator=denominator+sum(executable);
     end
 
-    coverage=numerator/denumerator;
+    coverage=numerator/denominator;
 
 


### PR DESCRIPTION
"Denominator" is the correct English name for the bottom part of
a fraction.
