### PR TITLE
BUG: Fix coverage calculation for empty files

### DIFF
--- a/MOcov/@MOcovMFile/get_coverage_xml.m
+++ b/MOcov/@MOcovMFile/get_coverage_xml.m
@@ -54,4 +54,10 @@ function xml=get_reportable_lines_xml(obj)
 
 function r=get_coverage_ratio(obj)
     executable=get_lines_executable(obj);
-    r=sum(get_lines_executed(obj) & executable) / sum(executable);
+    numerator = sum(get_lines_executed(obj) & executable);
+    denominator = sum(executable);
+    if denominator==0
+        r=1;
+    else
+        r=numerator/denominator;
+    end

--- a/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
+++ b/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
@@ -66,6 +66,10 @@ function coverage=compute_coverage(obj)
         denominator=denominator+sum(able);
     end
 
-    coverage=numerator/denominator;
+    if denominator==0
+        coverage=1;
+    else
+        coverage=numerator/denominator;
+    end
 
 

--- a/MOcov/@MOcovMFileCollection/write_html.m
+++ b/MOcov/@MOcovMFileCollection/write_html.m
@@ -96,7 +96,11 @@ function stats=get_stats(mfiles)
 
         executed(~executable)=false;
 
-        coverage=100*sum(executed)/sum(executable);
+        if sum(executable)==0
+            coverage=100;
+        else
+            coverage=100*sum(executed)/sum(executable);
+        end
 
         stat=[numel(executable),...
                      sum(executable),...

--- a/MOcov/@MOcovMFileCollection/write_html_dir.m
+++ b/MOcov/@MOcovMFileCollection/write_html_dir.m
@@ -111,7 +111,11 @@ function stats=get_stats(mfiles)
 
         executed(~executable)=false;
 
-        coverage=100*sum(executed)/sum(executable);
+        if sum(executable)==0
+            coverage=100;
+        else
+            coverage=100*sum(executed)/sum(executable);
+        end
 
         stat=[numel(executable),...
                      sum(executable),...

--- a/MOcov/@MOcovMFileCollection/write_xml_file.m
+++ b/MOcov/@MOcovMFileCollection/write_xml_file.m
@@ -83,6 +83,10 @@ function coverage=compute_coverage(obj)
         denominator=denominator+sum(executable);
     end
 
-    coverage=numerator/denominator;
+    if denominator==0
+        coverage=1;
+    else
+        coverage=numerator/denominator;
+    end
 
 


### PR DESCRIPTION
For files with no executable lines, the coverage report should
have a nominal 100% coverage rate. This is the behaviour of other
coverage packages, such as those for [Python coverage](https://coverage.readthedocs.org/en/coverage-4.0.3/changes.html#version-4-0-20-september-2015).

Previously, files without any executable lines would report a
coverage of "NaN%", due to the division by 0.
