### PR TITLE
BLD: Only run tests once on Shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ before_install:
 script:
     - if [[  "$SHIPPABLE" == "true"  ]]; then
           make test JUNIT_XML=../MOcov/shippable/testresults/testresults.xml;
-      fi
-    - if [[  "$TRAVIS" == "true"  ]]; then
+      elif [[  "$TRAVIS" == "true"  ]]; then
           make test;
       fi
 


### PR DESCRIPTION
Since the environment variable TRAVIS is set to "true" on Shippable,
the command for Travis-CI should only be run if the SHIPPABLE
value is not "true". Otherwise tests are run twice on Shippable.
