### PR TITLE
Add ability to specify patterns to be excluded from coverage report

### DIFF
--- a/MOcov/@MOcovMFileCollection/MOcovMFileCollection.m
+++ b/MOcov/@MOcovMFileCollection/MOcovMFileCollection.m
@@ -1,4 +1,4 @@
-function obj=MOcovMFileCollection(root_dir, method, monitor)
+function obj=MOcovMFileCollection(root_dir, method, monitor, exclude_pat)
 % instantiate MOcovMFileCollection
 %
 % obj=MOcovMFileCollection(root_dir, method, monitor)
@@ -13,8 +13,13 @@ function obj=MOcovMFileCollection(root_dir, method, monitor)
 %                           - 'profile' use Matlab profiler
 %                           default: 'file'
 %   monitor                 optional MOcovProgressMonitor instance
+%   exclude_pat             Optional cell array of patterns to exclude.
 %
 % See also: mocov
+
+    if nargin<4 || isempty(exclude_pat)
+        exclude_pat={};
+    end
 
     if nargin<3 || isempty(monitor)
         monitor=MOcovProgressMonitor();
@@ -27,6 +32,7 @@ function obj=MOcovMFileCollection(root_dir, method, monitor)
     props=struct();
     props.root_dir=root_dir;
     props.monitor=monitor;
+    props.exclude_pat=exclude_pat;
     props.mfiles=[];
     props.orig_path=[];
     props.temp_dir=[];

--- a/MOcov/@MOcovMFileCollection/prepare.m
+++ b/MOcov/@MOcovMFileCollection/prepare.m
@@ -14,7 +14,7 @@ function obj=prepare(obj)
 
     monitor=obj.monitor;
 
-    fns=mocov_find_files(obj.root_dir,'*.m',monitor);
+    fns=mocov_find_files(obj.root_dir,'*.m',monitor,obj.exclude_pat);
     n=numel(fns);
 
     mfiles=cell(n,1);

--- a/MOcov/mocov.m
+++ b/MOcov/mocov.m
@@ -16,6 +16,10 @@ function varargout=mocov(varargin)
 %                               Mutually exclusive with '-e' option.
 %   '-cover', covd              Find coverage for files in dir covd and all
 %                               of its subdirectories
+%   '-cover_exclude', pat       (optional) Exclude files and directories
+%                               which match this pattern, even if they are
+%                               in covd. Can be used multiple times to
+%                               specify multiple patterns to match.
 %   '-cover_json_file', cj      (optional) Store coverage information in
 % `                             file cj in JSON format [use with coveralls]
 %   '-cover_xml_file', xc       (optional) Store coverage information in
@@ -81,7 +85,8 @@ function varargout=mocov(varargin)
     monitor=MOcovProgressMonitor(opt.verbose);
     mfile_collection=MOcovMFileCollection(opt.cover,...
                                                     opt.method,...
-                                                    monitor);
+                                                    monitor,...
+                                                    opt.excludes);
     mfile_collection=prepare(mfile_collection);
     cleaner_collection=onCleanup(@()cleanup(mfile_collection));                                                    
 
@@ -151,6 +156,7 @@ function opt=parse_inputs(varargin)
 
     defaults=struct();
     defaults.coverage_dir=pwd();
+    defaults.excludes={};
     defaults.html_dir=[];
     defaults.cobertura_xml=[];
     defaults.coveralls_json=[];
@@ -184,6 +190,10 @@ function opt=parse_inputs(varargin)
                 case '-cover'
                     k=k+1;
                     opt.cover=varargin{k};
+
+                case '-cover_exclude'
+                    k=k+1;
+                    opt.excludes(end+1)=varargin(k);
 
                 case '-verbose'
                     opt.verbose=opt.verbose+1;

--- a/MOcov/mocov_find_files.m
+++ b/MOcov/mocov_find_files.m
@@ -12,7 +12,9 @@ function res=mocov_find_files(root_dir, file_pat, monitor, exclude_pat)
 %                       is used, corresponding to all files.
 %   monitor             Optional progress monitory that supports a
 %                       'notify' method.
-%   exclude_pat         Optional cell array of patterns to exclude.
+%   exclude_pat         Optional cell array of patterns to exclude. Both
+%                       files and directories which match one of these
+%                       patterns will be omitted from the output.
 %
 % Output:
 %   res                 Kx1 cell with names of files in root_dir matching

--- a/MOcov/mocov_find_files.m
+++ b/MOcov/mocov_find_files.m
@@ -89,7 +89,7 @@ function res=find_files_recursively(root_dir,file_re,monitor,exclude_re)
             if ~isempty(regexp(fn,exclude_re,'once'));
                 continue;
             elseif isdir(path_fn)
-                res=find_files_recursively(path_fn,file_re,monitor);
+                res=find_files_recursively(path_fn,file_re,monitor,exclude_re);
             elseif ~isempty(regexp(fn,file_re,'once'));
                 res={path_fn};
                 if ~isempty(monitor)


### PR DESCRIPTION
Closes #4.

Adds -cover_exclude option, which can be to specify patterns for directories and files which should be excluded from the coverage report. This can be used multiple times to specify multiple patterns.

The implementation method was as discussed on the thread for #4.

I have not altered README.md, so there is currently no documentation for this feature.
