### PR TITLE
[BUG] Fix removal of empty array in cell array for Octave compatibility of the exclude functionality

### DIFF
--- a/MOcov/mocov_find_files.m
+++ b/MOcov/mocov_find_files.m
@@ -111,4 +111,5 @@ function res=find_files_recursively(root_dir,file_re,monitor,exclude_re)
         res_cell{k}=res;
     end
 
+    res_cell=res_cell(~cellfun('isempty',res_cell));
     res=cat(1,res_cell{:});

--- a/MOcov/mocov_find_files.m
+++ b/MOcov/mocov_find_files.m
@@ -111,5 +111,5 @@ function res=find_files_recursively(root_dir,file_re,monitor,exclude_re)
         res_cell{k}=res;
     end
 
-    res_cell=res_cell(~cellfun('isempty',res_cell));
+    res_cell=res_cell(~cellfun(@isempty,res_cell));
     res=cat(1,res_cell{:});


### PR DESCRIPTION
Encountered this bug while trying to use the exclude patter functionality of MOcov in Octave.

I would get this error:

```octave

octave:4> res=moxunit_runtests('SimTest_qmt_bssfp.m','-with_coverage','-cover','../../src','-cover_exclude','*bSSFP_sim*','-cover_json_file','coverage_SimTest_qmt_bssfp.json')
suite: 3 tests
running coverage with parameters: -expression <function_handle> -cover ../../src -cover_exclude *bSSFP_sim* -cover_json_file coverage_SimTest_qmt_bssfp.json 
joined = |^.*bSSFP_sim.*$
error: invalid conversion from real matrix to real scalar
error: file id must be a file object or integer value
error: called from
    MOcovMFile>get_mfile_props at line 27 column 8
    MOcovMFile at line 15 column 10
    prepare at line 23 column 17
    mocov at line 92 column 21
    moxunit_runtests>run_all_tests at line 205 column 20
    moxunit_runtests at line 102 column 16
octave:4> 

```

I found that it occurs because the concatenation of cells of filenames contained a mix of empty arrays and cells. In Matlab, both of these are removed in the concatenation:

![2](https://user-images.githubusercontent.com/1421029/39900269-34f5dab2-549b-11e8-9a19-e41450028eab.png)

but in Octave, the empty cell in the cell array remains there after the concatenation:

![3](https://user-images.githubusercontent.com/1421029/39900311-95f954a6-549b-11e8-927a-1e3c8c914aa0.png)

This is a [known bug](https://savannah.gnu.org/bugs/?func=detailitem&item_id=49759) in Octave. Although a poster (*amro_octave*) suggests that the bug was fixed in 4.2.0, I was using version 4.2.1 when I encountered it.

The line I added before the concatenation solved the issue for me (after would have likely worked too).