### PR TITLE
Added missing sprintf in calls to notify.

### DIFF
--- a/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
+++ b/MOcov/@MOcovMFileCollection/write_cobertura_xml.m
@@ -1,11 +1,11 @@
 function write_cobertura_xml(obj, output_fn)
     monitor=obj.monitor;
-    notify(monitor,'Writing xml files in %s', output_fn);
+    notify(monitor,sprintf('Writing xml files in %s', output_fn));
 
 
 
     overall_coverage=compute_coverage(obj);
-    notify(monitor,'Overal coverage is %.3f', overall_coverage);
+    notify(monitor,sprintf('Overall coverage is %.3f', overall_coverage));
     header=sprintf(['<?xml version="1.0"?>\n'...
                     '<coverage line-rate="%.3f" branch-rate="1.0">'],...
                     overall_coverage);

--- a/MOcov/@MOcovMFileCollection/write_coveralls_json.m
+++ b/MOcov/@MOcovMFileCollection/write_coveralls_json.m
@@ -1,10 +1,10 @@
 function write_coveralls_json(obj,output_fn)
     monitor=obj.monitor;
-    notify(monitor,'Writing JSON file to %s', output_fn);
+    notify(monitor,sprintf('Writing JSON file to %s', output_fn));
 
     json=get_coverage_json(obj);
     fid=fopen(output_fn,'w');
     cleaner=onCleanup(@()fclose(fid));
     fprintf(fid,'%s',json);
 
-    notify(monitor,'Completed writing JSON file to %s', output_fn);
+    notify(monitor,sprintf('Completed writing JSON file to %s', output_fn));

--- a/MOcov/@MOcovMFileCollection/write_html.m
+++ b/MOcov/@MOcovMFileCollection/write_html.m
@@ -12,7 +12,7 @@ function write_html(obj, output_dir)
     n=numel(mfiles);
     mfile_node_fns=cell(n,1);
 
-    notify(monitor,'Writing html files in %s', output_dir);
+    notify(monitor,sprintf('Writing html files in %s', output_dir));
 
     for k=1:n
         node_rel_fn=sprintf('node%d.html',k);

--- a/MOcov/@MOcovMFileCollection/write_html_dir.m
+++ b/MOcov/@MOcovMFileCollection/write_html_dir.m
@@ -25,7 +25,7 @@ function write_html_dir(obj, output_dir)
     mfile_node_fns=cell(n,1);
 
     % write single HTML file for each m-file
-    notify(monitor,'Writing html files in %s', output_dir);
+    notify(monitor,sprintf('Writing html files in %s', output_dir));
 
     for k=1:n
         node_rel_fn=sprintf('node%d.html',k);

--- a/MOcov/@MOcovMFileCollection/write_xml_file.m
+++ b/MOcov/@MOcovMFileCollection/write_xml_file.m
@@ -14,11 +14,11 @@ function write_xml_file(obj, output_fn)
     branch_rate=0;
 
     monitor=obj.monitor;
-    notify(monitor,'Writing xml files in %s', output_fn);
+    notify(monitor,sprintf('Writing xml files in %s', output_fn));
 
     % write header
     overall_coverage=compute_coverage(obj);
-    notify(monitor,'Overal coverage is %.3f', overall_coverage);
+    notify(monitor,sprintf('Overall coverage is %.3f', overall_coverage));
     header=sprintf(['<?xml version="1.0"?>\n'...
                     '<coverage line-rate="%.3f" branch-rate="%.3f">'],...
                     overall_coverage,branch_rate);


### PR DESCRIPTION
I parse the output of `mocov(..., '-verbose')` to get code coverage recognized by GitLab CI, and I noticed some format strings weren't getting passed through `sprintf()` first. 

Example output, prior to fix:
```
Writing xml files in %s
Overal coverage is %.3f
.....................................................written to /app/MOcov_coverage.xml
```

Post fix:
```
Writing xml files in /app/MOcov_coverage.xml
Overall coverage is 0.073
........written to /app/MOcov_coverage.xml
```

Let me know if you need anything else from me to accept this pull request.