### PR TITLE
Remove depreciated

### DIFF
--- a/MOcov/@MOcovMFile/write_lines_with_prefix.m
+++ b/MOcov/@MOcovMFile/write_lines_with_prefix.m
@@ -46,7 +46,7 @@ function write_lines_with_prefix(obj, fn, decorator)
 
 
 function mkdir_recursively(pth)
-    if ~isempty(pth) && ~isdir(pth)
+    if ~isempty(pth) && ~mocov_util_isfolder(pth)
         parent=fileparts(pth);
         mkdir_recursively(parent);
         mkdir(pth);

--- a/MOcov/@MOcovMFileCollection/write_html.m
+++ b/MOcov/@MOcovMFileCollection/write_html.m
@@ -1,5 +1,5 @@
 function write_html(obj, output_dir)
-    if ~isdir(output_dir)
+    if ~mocov_util_isfolder(output_dir)
         mkdir(output_dir);
     end
 

--- a/MOcov/@MOcovMFileCollection/write_html_dir.m
+++ b/MOcov/@MOcovMFileCollection/write_html_dir.m
@@ -11,7 +11,7 @@ function write_html_dir(obj, output_dir)
 %   - this function writes a file index.html, as well as node*.html files
 %     for each individual MOcovMFile.
 
-    if ~isdir(output_dir)
+    if ~mocov_util_isfolder(output_dir)
         mkdir(output_dir);
     end
 

--- a/MOcov/mocov.m
+++ b/MOcov/mocov.m
@@ -234,7 +234,7 @@ function opt=parse_inputs(varargin)
 
 
 function check_inputs(opt)
-    if ~isdir(opt.coverage_dir)
+    if ~mocov_util_isfolder(opt.coverage_dir)
         error('input dir ''%s'' does not exist', opt.coverage_dir);
     end
 

--- a/MOcov/mocov_find_files.m
+++ b/MOcov/mocov_find_files.m
@@ -26,7 +26,7 @@ function res=mocov_find_files(root_dir, file_pat, monitor, exclude_pat)
         root_dir='';
     end
 
-    if ~(isempty(root_dir) || isdir(root_dir))
+    if ~(isempty(root_dir) || mocov_util_isfolder(root_dir))
         error('first argument must be directory');
     end
 
@@ -98,7 +98,7 @@ function res=find_files_recursively(root_dir,file_re,monitor,exclude_re)
 
             if ~isempty(regexp(fn,exclude_re,'once'));
                 continue;
-            elseif isdir(path_fn)
+            elseif mocov_util_isfolder(path_fn)
                 res=find_files_recursively(path_fn,file_re,...
                                                 monitor,exclude_re);
             elseif ~isempty(regexp(fn,file_re,'once'));

--- a/MOcov/mocov_util_get_root_path_containing.m
+++ b/MOcov/mocov_util_get_root_path_containing.m
@@ -43,6 +43,6 @@ function tf=has_in_dir(needle, child_dir)
 
     names={d.name};
 
-    tf=~isempty(strmatch(needle,names,'exact'));
+    tf=(sum(strcmp(needle,names))>=1);
 
 

--- a/MOcov/mocov_util_isfolder.m
+++ b/MOcov/mocov_util_isfolder.m
@@ -1,0 +1,38 @@
+function tf=mocov_util_isfolder(folderName)
+% return true if the argument is a folder
+% 
+% This function is needed to keep compatibility with older versions of Octave and Matlab
+% for which the function isfolder didn't exist yet.
+% 
+% tf=mocov_util_isfolder(folderName)
+%
+% Output:
+%   tf               True if the argument points to an existing directory
+%
+
+
+    persistent cached_handle;
+
+    if ~isempty(cached_handle)
+        tf = cached_handle(folderName);
+        return;
+    end
+
+    % We find out which function we need to redirect to
+    v = mocov_util_platform_version();
+    isfolder_available = false;
+    if mocov_util_platform_is_octave()
+        isfolder_available = (v(1) >= 5);
+    else
+        isfolder_available = (v(1) >= 10) || ((v(1) >= 9) && (v(2) >= 3));
+    end
+
+    % Call the appropriate function
+    if isfolder_available
+        cached_handle = @isfolder;
+    else
+        cached_handle = @isdir;
+    end
+
+    tf = cached_handle(folderName);
+

--- a/MOcov/mocov_util_platform_version.m
+++ b/MOcov/mocov_util_platform_version.m
@@ -1,0 +1,21 @@
+function v=mocov_util_platform_version()
+% return the version of Matlab or Octave
+%
+% v=mocov_util_platform_version()
+%
+% Output:
+%   v               Vector with two (Matlab) or three (Octave) elements,
+%                   for example 8.5 (for Matlab) or 4.0.3) for Octave)
+%
+
+
+    version_str=version();
+
+    parts=regexp(version_str,'\s','split');
+    first_part=parts{1};
+
+    num_parts=regexp(first_part,'\.','split');
+    v=cellfun(@str2num,num_parts);
+
+
+

--- a/tests/test_mocov_line_covered.m
+++ b/tests/test_mocov_line_covered.m
@@ -46,7 +46,7 @@ function test_mocov_line_covered_basics()
     for k=1:n
         s_lines=s.line_count{k};
 
-        s2_pos=strmatch(s.keys{k},s2.keys);
+        s2_pos=find(strcmp(s.keys{k},s2.keys));
         assert(numel(s2_pos)==1);
 
         s2_lines=s2.line_count{s2_pos};


### PR DESCRIPTION
Removing some depreciated functions. To keep compatibility with not too old releases such as Octave 4.2, `isfolder` is still redirected to `isdir` in this case.