### PR TITLE
Added windows support

### DIFF
--- a/MOcov/mocov_get_absolute_path.m
+++ b/MOcov/mocov_get_absolute_path.m
@@ -19,8 +19,9 @@ function abs_fn=mocov_get_absolute_path(fn)
     abs_fn=clean_path_string(abs_fn);
 
 function clean_abs_fn=clean_path_string(abs_fn)
-
-    re=regexptranslate('escape',filesep());
+    
+    fs=filesep();
+    re=regexptranslate('escape',fs);
 
     while true
         sp=regexp(abs_fn,re,'split');
@@ -51,15 +52,18 @@ function clean_abs_fn=clean_path_string(abs_fn)
         end
 
         parts=[sp(keep);...
-                    repmat({filesep()},1,sum(keep))];
+                    repmat({fs},1,sum(keep))];
 
-        clean_abs_fn=strrep(cat(2,parts{:}),...
-                            [filesep() filesep()], ...
-                            filesep());
+        clean_abs_fn=strrep(cat(2,parts{:}), [fs fs], fs);
 
         % deal with filesep at the end of the path
-        while numel(clean_abs_fn)>1 && clean_abs_fn(end)==filesep();
-            clean_abs_fn=clean_abs_fn(1:(end-1));
+        while numel(clean_abs_fn)>1 && clean_abs_fn(end)==fs
+            if ispc() && numel(clean_abs_fn)==3 && clean_abs_fn(end-1)==':' 
+                % Do not strip the slash on windows drive letters ( e.g c:\ )
+                break
+            else    
+                clean_abs_fn=clean_abs_fn(1:(end-1));
+            end
         end
 
         if strcmp(clean_abs_fn,abs_fn)

--- a/tests/test_get_absolute_path.m
+++ b/tests/test_get_absolute_path.m
@@ -6,8 +6,20 @@ function test_suite = test_get_absolute_path
     initTestSuite;
 
 function test_get_absolute_path_basics()
-    aeq=@(a,b)assertEqual(mocov_get_absolute_path(a),b);
+    % Modify test to support windows
+    if ispc()
+        fs = filesep();
+        sps = @(str)strrep(str,'/',fs);
+  
+        % Prepend tests with 'c:' and flip to windows filesep
+        aeq=@(a,b)assertEqual(mocov_get_absolute_path(...
+            ['c:',sps(a)]),...
+            ['c:',sps(b)]);
+    else
+        aeq = @(a,b)assertEqual(mocov_get_absolute_path(a),b);
+    end
 
+    % Absolute path checks starting at a drive root
     aeq('/','/');
     aeq('/foo/../','/');
     aeq('/foo/..//','/');
@@ -15,10 +27,10 @@ function test_get_absolute_path_basics()
     aeq('/foo/../.','/');
     aeq('/foo/.././','/');
 
-
+    % Present working directory
     orig_pwd=pwd();
     cleaner=onCleanup(@()cd(orig_pwd));
     p=fileparts(mfilename('fullpath'));
     cd(p);
-    aeq('',p);
+    assertEqual(mocov_get_absolute_path(''),p)
 

--- a/tests/test_mocov_get_relative_path.m
+++ b/tests/test_mocov_get_relative_path.m
@@ -7,7 +7,9 @@ function test_suite = test_mocov_get_relative_path()
 
 
 function test_mocov_get_relative_path_basics()
-    aeq=@(a,varargin)assertEqual(a,mocov_get_relative_path(varargin{:}));
+    fs = filesep();
+    sps = @(str)strrep(str,'/',fs);
+    aeq=@(a,varargin)assertEqual(sps(a),sps(mocov_get_relative_path(varargin{:})));
 
     aeq('foo','','foo');
     aeq('foo','bar','bar/foo');


### PR DESCRIPTION
These changes add suppport for Windows within get_absolute_path.  This was primarily a filesep issue, but one must also be careful when dealing the paths like “c:/“.  I did not add support for UNC path names on Windows.