### PR TITLE
Fix multiline function definitions

### DIFF
--- a/MOcov/@MOcovMFile/MOcovMFile.m
+++ b/MOcov/@MOcovMFile/MOcovMFile.m
@@ -108,6 +108,9 @@ function tf=line_is_function_def(line)
                  '(?<name>[a-zA-Z]\w*)(\([^\)]*\))?'];
 
     tf=~isempty(regexp([newline line],pat,'once'));
+    % addition, so that defs that span multiple lines with ... get 
+    % recognized properly
+    tf = tf || ~isempty(regexp(line,'function\s*\[.*\].*\.\.\.','once'));
 
 function tf=line_is_class_def(line)
     % returns true if the line opens a class definition
@@ -143,4 +146,5 @@ function tf=line_ends_with_end_statement(line)
 function tf=line_has_line_continuation(line)
     % returns true if the line contains a line continuation
     tf=~isempty(regexp(line,'\.\.\.','once'));
+   
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # MOcov [![Build Status](https://travis-ci.org/MOcov/MOcov.svg?branch=master)](https://travis-ci.org/MOcov/MOcov) 
-### (hotfixed version to support function definitions spanning multiple lines)
 
 MOcov is a coverage report generator for Matlab and GNU Octave.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MOcov [![Build Status](https://travis-ci.org/MOcov/MOcov.svg?branch=master)](https://travis-ci.org/MOcov/MOcov)
+# MOcov [![Build Status](https://travis-ci.org/MOcov/MOcov.svg?branch=master)](https://travis-ci.org/MOcov/MOcov) (sloppy hotfixed version by to support function definitions spanning multiple lines)
 
 MOcov is a coverage report generator for Matlab and GNU Octave.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# MOcov [![Build Status](https://travis-ci.org/MOcov/MOcov.svg?branch=master)](https://travis-ci.org/MOcov/MOcov) (sloppy hotfixed version by to support function definitions spanning multiple lines)
+# MOcov [![Build Status](https://travis-ci.org/MOcov/MOcov.svg?branch=master)](https://travis-ci.org/MOcov/MOcov) 
+### (hotfixed version to support function definitions spanning multiple lines)
 
 MOcov is a coverage report generator for Matlab and GNU Octave.
 


### PR DESCRIPTION
As stated in #25 MOCov currently has trouble with function definitions that are longer then one line and connected via `...`
This is fixed by introducing another measure of what a function definition is and taking that into account aswell. 