### PR TITLE
Parse double quote strings correctly

### DIFF
--- a/MOcov/@MOcovMFile/MOcovMFile.m
+++ b/MOcov/@MOcovMFile/MOcovMFile.m
@@ -47,7 +47,7 @@ function props=get_mfile_props(fn)
     for k=1:n
         line=lines{k};
 
-        line_without_quotes=regexprep(line,'''.*''','');
+        line_without_quotes=regexprep(line,'''.*''|".*"','');
 
         comment_start=find(line_without_quotes=='%',1);
         if isempty(comment_start)


### PR DESCRIPTION
Previously only single quoted strings were removed during parsing. This lead to parser errors when using the `file` method under certain circumstances.

For example on such a line:

```Matlab
error("This is a double qouted string with a %s in it.", ...
      string_variable);
```