### PR TITLE
ENH: cleanup of line_covered, make sure strings are not truncated (mo…

### DIFF
--- a/MOcov/mocov_line_covered.c
+++ b/MOcov/mocov_line_covered.c
@@ -13,8 +13,8 @@
 // for allocating and freeing space for these structs when needed.
 //
 // To help with debugging, the code defines and uses `debug()` en
-// `debug_print_state()` calls. When enabled (not by defaylt), this prints
-// extensive output that migh help debugging.
+// `debug_print_state()` calls. When enabled (not by default), this prints
+// extensive output that might help debugging.
 
 #include "mex.h"
 #include <assert.h>

--- a/MOcov/mocov_line_covered.c
+++ b/MOcov/mocov_line_covered.c
@@ -189,8 +189,9 @@ void raise_mex_error(const char *error_id_label, const char *error_message) {
     }
 
     // Concatenate the prefix and the original error_id into new_errorid
-    snprintf(error_id, MAX_ERROR_ID_LENGTH, "%s%s", ERROR_ID_PREFIX,
-             error_id_label);
+    size_t prefix_len = strlen(ERROR_ID_PREFIX);
+    snprintf(error_id, MAX_ERROR_ID_LENGTH, "%s", ERROR_ID_PREFIX);
+    strncat(error_id, error_id_label, MAX_ERROR_ID_LENGTH - prefix_len - 1);
 
     // Call the original mexErrMsgIdAndTxt function with the new error_id
     mexErrMsgIdAndTxt(error_id, error_message);

--- a/MOcov/mocov_line_covered.c
+++ b/MOcov/mocov_line_covered.c
@@ -13,7 +13,8 @@
 // for allocating and freeing space for these structs when needed.
 //
 // To help with debugging, the code defines and uses `debug()` en
-// `debug_print_state()` calls.
+// `debug_print_state()` calls. When enabled (not by defaylt), this prints
+// extensive output that migh help debugging.
 
 #include "mex.h"
 #include <assert.h>

--- a/MOcov/mocov_line_covered.c
+++ b/MOcov/mocov_line_covered.c
@@ -68,15 +68,15 @@ typedef struct {
 
 // Declare constants
 // (these should not be changed unless you really know what you are doing)
-const int GENERAL_STRING_BUFFER_LENGHTH = 100;
-const int MAX_ERROR_ID_LENGTH = GENERAL_STRING_BUFFER_LENGHTH;
-const int MAX_ERROR_MESSAGE_LENGTH = GENERAL_STRING_BUFFER_LENGHTH;
+#define GENERAL_STRING_BUFFER_LENGTH 100
+#define MAX_ERROR_ID_LENGTH 200
+#define MAX_ERROR_MESSAGE_LENGTH GENERAL_STRING_BUFFER_LENGTH
 
 const char *ERROR_ID_PREFIX = "mocov_line_covered:";
 const char *MALLOC_ERROR_MESSAGE_PREFIX = "memory allocation failed: ";
 
 #if IS_DEBUG
-const int DEBUG_BUFFER_SIZE = GENERAL_STRING_BUFFER_LENGHTH;
+const int DEBUG_BUFFER_SIZE = GENERAL_STRING_BUFFER_LENGTH;
 const char *DEBUG_PREFIX = "DEBUG: ";
 #endif
 
@@ -441,7 +441,7 @@ void return_state(const mxArray *prhs[], int nlhs, mxArray *plhs[]) {
                         "This function accepts at most one output.");
 
     } else if (nlhs == 0) {
-        // No output, nothing to do, we can exit this function
+        // No output, nothing to do, we can exit this function early.
         return;
     }
 
@@ -622,7 +622,7 @@ void set_state(const mxArray *prhs[], int nlhs, mxArray *plhs[]) {
     debug_print_state();
 }
 
-// Helper function to handle nrhs == 4 case (update the state with a specific
+// Helper function to handle nrhs == 3 case (update the state with a specific
 // line state)
 void update_state(const mxArray *prhs[], int nlhs, mxArray *plhs[]) {
 
@@ -641,8 +641,6 @@ void update_state(const mxArray *prhs[], int nlhs, mxArray *plhs[]) {
     debug("call 3 args");
     add_line_covered(idx, prhs[1], line_number);
 
-    // free fn pointer after use
-    // free(fn);
     debug("updating state: done, state is now");
     debug_print_state();
 }
@@ -659,9 +657,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     }
 
     if (nrhs == 3) {
-        // Update the state for a specific line in a file.
-        // Optimization: because `nrhs == 4` is the most frequently used
-        // use of this function, this is checked first.
+        // Most common case: update the state for a specific line in a file.
         update_state(prhs, nlhs, plhs);
     } else if (nrhs == 1) {
         // Set the state from a struct s with s.keys and s.line_count


### PR DESCRIPTION
This should get rid of the (harmless) message during compilation of `mocov_line_covered.c`.

```
mocov_line_covered.c:191:48: warning: ‘%s’ directive output may be truncated writing up to 98 bytes into a region of size between 2 and 100 [-Wformat-truncation=]
  191 |     snprintf(error_id, MAX_ERROR_ID_LENGTH, "%s%s", ERROR_ID_PREFIX,
      |                                                ^~
In file included from /usr/include/stdio.h:980,
                 from mocov_line_covered.c:23:
In function ‘snprintf’,
    inlined from ‘raise_mex_error’ at mocov_line_covered.c:191:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__snprintf_chk’ output between 1 and 197 bytes into a destination of size 100
   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   55 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
```

Also, a few tweaks on the comments.