### PR TITLE
FIX: 'illegal input' thrown in mocov_line_covered when using cover_method "profile"

### DIFF
--- a/MOcov/mocov_line_covered.m
+++ b/MOcov/mocov_line_covered.m
@@ -56,12 +56,15 @@ function state = mocov_line_covered(varargin)
             cached_line_count = state.line_count;
             return
 
-        case 3
+        case {3, 4}
             % add a line covered
             index = varargin{1};
             key = varargin{2};
             line = varargin{3};
             count = 1;
+            if nargin == 4
+                count = varargin{4};
+            end
 
             if ~isnumeric(index) || ~ischar(key) || ~isnumeric(line) || ...
                     numel(index) ~= 1 || round(index) ~= index || ...


### PR DESCRIPTION
This PR fixes an error when MOcov is called with cover_method "profile" in Matlab (i.e., line coverage is provided by the profiler).
It seems like the changes introduced in cd81d7e80908fe0a591823daef19a2363118a76b result in an argument mismatch wen `mocov_line_covered` is called when using the MATLAB profiler to obtain line counts.

### Explanation
The culprit is this change: https://github.com/MOxUnit/MOcov/commit/cd81d7e80908fe0a591823daef19a2363118a76b#diff-111ecb75d165b55eff2b813b14437d83f24ee75561941045abebc422b4d69e1d

The resulting code block https://github.com/MOxUnit/MOcov/blob/cd81d7e80908fe0a591823daef19a2363118a76b/MOcov/mocov_line_covered.m#L59-L72

now checks for three instead of four arguments, setting count to 1 (which is the case when cover_method "file" is used). 

However, when using the "profile" method, the function is still called with four arguments because there the number of hits/counts is obtained from the profiler directly:

https://github.com/MOxUnit/MOcov/blob/cd81d7e80908fe0a591823daef19a2363118a76b/MOcov/%40MOcovMFileCollection/add_lines_executed_count.m#L65-L69

### Suggested solution
I suggest to reinstate the case of four arguments. A minimal code solution could be checking for both cases with `case {3, 4}` and then setting `count` from the fourth argument, if available:

```matlab
  case {3, 4} 
     % add a line covered 
     index = varargin{1}; 
     key = varargin{2}; 
     line = varargin{3}; 
     count = 1;
     if nargin == 4
         count = varargin{4};
     end 
  
     if ~isnumeric(index) || ~ischar(key) || ~isnumeric(line) || ... 
             numel(index) ~= 1 || round(index) ~= index || ... 
             numel(line) ~= 1 || round(line) ~= line 
         error('illegal argument'); 
     end 
```

Is this okay or should `case 4` be separated?

Since this is a seemingly small change I directly created a PR. I didn't check the interplay with the mex-version though and it might also make sense to prepare a test for this, so this might also need some more refinement.